### PR TITLE
Don't duplicate config if run multiple times

### DIFF
--- a/packer/scripts/configure-consul-dns-resolution.sh
+++ b/packer/scripts/configure-consul-dns-resolution.sh
@@ -4,19 +4,19 @@ set -euo pipefail
 # setup systemd-resolved to send *.consul DNS requests to Consul
 mkdir -p /etc/systemd/resolved.conf.d/
 
-cat <<-EOF >> /etc/systemd/resolved.conf.d/consul.conf
+cat <<-EOF > /etc/systemd/resolved.conf.d/consul.conf
 [Resolve]
 DNS=127.0.0.1:8600
 Domains=~consul
 EOF
 
-cat <<-EOF >> /etc/systemd/resolved.conf.d/nomad.conf
+cat <<-EOF > /etc/systemd/resolved.conf.d/nomad.conf
 [Resolve]
 # this is required to get systemd-resolved listening on the nomad
 # bridge interface.
 DNSStubListenerExtra=172.26.64.1
 EOF
 
-cat <<-EOF >> /etc/docker/daemon.json
+cat <<-EOF > /etc/docker/daemon.json
 { "dns" : [ "172.26.64.1" , "8.8.8.8" ] }
 EOF

--- a/packer/scripts/install-cni-plugins.sh
+++ b/packer/scripts/install-cni-plugins.sh
@@ -14,7 +14,7 @@ mkdir -p /opt/cni/bin
 curl -sSL "$url" | tar -C /opt/cni/bin -xzf -
 
 # Ensure container traffic through bridge networks is allowed
-cat <<-EOF >> /etc/sysctl.d/99-cni-bridge-settings.conf
+cat <<-EOF > /etc/sysctl.d/99-cni-bridge-settings.conf
 net.bridge.bridge-nf-call-arptables = 1
 net.bridge.bridge-nf-call-ip6tables = 1
 net.bridge.bridge-nf-call-iptables = 1

--- a/packer/scripts/install-libc6-from-groovy.sh
+++ b/packer/scripts/install-libc6-from-groovy.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo "deb http://us.archive.ubuntu.com/ubuntu groovy main" >> /etc/apt/sources.list
+if ! grep "deb http://us.archive.ubuntu.com/ubuntu groovy main" /etc/apt/sources.list
+then
+    echo "deb http://us.archive.ubuntu.com/ubuntu groovy main" >> /etc/apt/sources.list
+fi
 apt-get -y update
 
 apt-get -y --no-install-recommends install libc6-dev

--- a/scripts/bootstrap-nomad.sh
+++ b/scripts/bootstrap-nomad.sh
@@ -12,14 +12,14 @@ token=$(jq -r '.auth.client_token' /vagrant/nomad-server-vault-token.json)
 
 # drop the Vault configuration file
 if [ "$ROLE" = "client" ]; then
-    cat <<-EOF >> /etc/nomad.d/vault.hcl
+    cat <<-EOF > /etc/nomad.d/vault.hcl
 vault {
   enabled          = true
   address          = "http://vault.service.consul:8200"
 }
 EOF
 else
-    cat <<-EOF >> /etc/nomad.d/vault.hcl
+    cat <<-EOF > /etc/nomad.d/vault.hcl
 vault {
   enabled          = true
   address          = "http://vault.service.consul:8200"

--- a/scripts/bootstrap-vault.sh
+++ b/scripts/bootstrap-vault.sh
@@ -6,7 +6,7 @@ sudo ln -sf /vagrant/config/vault-${ROLE}.hcl /etc/vault.d/vault.hcl
 
 # drop the Consul service registration file. this is required because
 # Vault currently doesn't support go-sockaddr templates.
-cat <<-EOF >> /etc/vault.d/consul-service-registration.hcl
+cat <<-EOF > /etc/vault.d/consul-service-registration.hcl
 # We aren't using Consul as the storage backend, but we still want
 # to register the Vault service with Consul
 service_registration "consul" {


### PR DESCRIPTION
The bootstrap process was written under the assumption it would only ever be run once. If someone ran a vagrant provision it would end up duplicating config content rather than overwriting what was already this. This should fix that.

Fixes #2.