### PR TITLE
Add note explaining host_volumes need to exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,9 @@ client {
   }
 }
 ```
+
+Note that Nomad expects these directories to exist already and the provisioning
+process won't automatically create them. If you want them in `/vagrant/host_volumes`
+then you should just create the directories in the `host_volumes` directory of
+this project prior to provisioning. If the directories don't exist, the clients
+will not start.


### PR DESCRIPTION
If you want to use host volumes, you need to create them before the provisioning process starts. The expectation is that they'll be in the `host_volumes` folder inside this project. The project directory is automatically mounted at `/vagrant` on all VMs that boot, so that directory is available on every VM. This wasn't explained in the README, which caused some confusion.

Fixes #1.